### PR TITLE
Fix main build pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Setup Pages ⚙️
         uses: actions/configure-pages@v4
-        with:
-          static_site_generator: next
 
       - name: Build with Next.js 🏗️
         run: npx next build


### PR DESCRIPTION
The static site generator option on setup pages is creating a duplicate .js config for next which is overriding the .ts nextjs config we have already setup.