### PR TITLE
Add button UI component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "jira-capacity-planner",
       "version": "0.1.0",
       "dependencies": {
+        "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "glob": "^10.4.5",
         "lru-cache": "^11.1.0",
@@ -16,7 +17,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-dropzone": "^14.3.8",
-        "recharts": "^2.15.3"
+        "recharts": "^2.15.3",
+        "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -10208,6 +10210,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "glob": "^10.4.5",
     "lru-cache": "^11.1.0",
@@ -20,7 +21,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-dropzone": "^14.3.8",
-    "recharts": "^2.15.3"
+    "recharts": "^2.15.3",
+    "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/components/button.tsx
+++ b/src/app/components/button.tsx
@@ -1,0 +1,33 @@
+import { ButtonHTMLAttributes, PropsWithChildren } from "react";
+
+type ButtonProps = {
+  variant: "link" | "button";
+  onClick?: () => void;
+  disabled?: boolean;
+  type?: "button" | "submit" | "reset";
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "className" | "onClick" | "disabled" | "type">;
+
+export function Button({
+  children,
+  variant,
+  onClick,
+  disabled = false,
+  type = "button",
+  ...rest
+}: PropsWithChildren<ButtonProps>) {
+  return (
+    <button
+      onClick={onClick}
+      type={type}
+      disabled={disabled}
+      className={`cursor-pointer transition-all duration-200 ${disabled ? "opacity-50 cursor-not-allowed" : ""} ${
+        variant === "link"
+          ? "text-sm font-medium text-indigo-600 hover:text-indigo-500 underline-offset-2 hover:underline"
+          : "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 active:translate-y-0.5 active:shadow-none"
+      }`}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/app/components/button.tsx
+++ b/src/app/components/button.tsx
@@ -1,10 +1,12 @@
 import { ButtonHTMLAttributes, PropsWithChildren } from "react";
+import { cn } from "../lib/ts/cn";
 
 type ButtonProps = {
   variant: "link" | "button";
   onClick?: () => void;
   disabled?: boolean;
   type?: "button" | "submit" | "reset";
+  className?: string;
 } & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "className" | "onClick" | "disabled" | "type">;
 
 export function Button({
@@ -13,6 +15,7 @@ export function Button({
   onClick,
   disabled = false,
   type = "button",
+  className,
   ...rest
 }: PropsWithChildren<ButtonProps>) {
   return (
@@ -20,11 +23,14 @@ export function Button({
       onClick={onClick}
       type={type}
       disabled={disabled}
-      className={`cursor-pointer transition-all duration-200 ${disabled ? "opacity-50 cursor-not-allowed" : ""} ${
-        variant === "link"
+      className={cn(
+        "cursor-pointer transition-all duration-200",
+        disabled && "opacity-50 cursor-not-allowed",
+        variant === "link" 
           ? "text-sm font-medium text-indigo-600 hover:text-indigo-500 underline-offset-2 hover:underline"
-          : "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 active:translate-y-0.5 active:shadow-none"
-      }`}
+          : "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 active:translate-y-0.5 active:shadow-none",
+        className
+      )}
       {...rest}
     >
       {children}

--- a/src/app/lib/ts/cn.ts
+++ b/src/app/lib/ts/cn.ts
@@ -1,0 +1,10 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+/**
+ * Combines multiple class names or class name objects and
+ * merges them intelligently with tailwind-merge to avoid conflicts
+ */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,6 +22,7 @@ import {
   ReferenceLine,
   Cell,
 } from "recharts";
+import { Button } from "./components/button";
 import { useDropzone } from "react-dropzone";
 
 // smple data
@@ -141,10 +142,7 @@ const AllInitiativesView = ({
   return (
     <div>
       <div className="flex justify-between items-center mb-4">
-        <button
-          onClick={onBack}
-          className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-        >
+        <Button variant="button" onClick={onBack}>
           <svg
             className="-ml-1 mr-2 h-5 w-5"
             xmlns="http://www.w3.org/2000/svg"
@@ -159,7 +157,7 @@ const AllInitiativesView = ({
             />
           </svg>
           Back to Overview
-        </button>
+        </Button>
         <div className="text-center">
           <h3 className="text-xl font-semibold text-gray-800">
             All Initiatives
@@ -179,12 +177,9 @@ const AllInitiativesView = ({
             </span>
           </div>
         </div>
-        <button
-          onClick={handleDownload}
-          className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md shadow-sm text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-        >
+        <Button variant="button" onClick={handleDownload}>
           Download CSV
-        </button>
+        </Button>
       </div>
 
       <div className="overflow-x-auto">
@@ -330,25 +325,24 @@ const DrilldownView = ({
 }) => {
   return (
     <div>
-      <button
-        onClick={onBack}
-        className="mb-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-      >
-        <svg
-          className="-ml-1 mr-2 h-5 w-5"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            fillRule="evenodd"
-            d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-            clipRule="evenodd"
-          />
-        </svg>
-        Back to Overview
-      </button>
+      <div className="mb-4">
+        <Button variant="button" onClick={onBack}>
+          <svg
+            className="-ml-1 mr-2 h-5 w-5"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fillRule="evenodd"
+              d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+              clipRule="evenodd"
+            />
+          </svg>
+          Back to Overview
+        </Button>
+      </div>
       <h3 className="text-xl font-semibold mb-4 text-gray-800">
         Initiatives Due in {monthData.name}
       </h3>
@@ -626,12 +620,9 @@ function JiraCapacityPlanner() {
                 )}
               </div>
               <div className="mt-4 text-center">
-                <button
-                  onClick={handleSampleData}
-                  className="w-full bg-indigo-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
+                <Button variant="button" onClick={handleSampleData}>
                   {"Or Use Sample Data"}
-                </button>
+                </Button>
               </div>
 
               {fileName && (
@@ -677,12 +668,9 @@ function JiraCapacityPlanner() {
                     Capacity vs Work Due Date
                   </h2>
                   {allInitiatives.length > 0 && (
-                    <button
-                      onClick={() => setPage("all")}
-                      className="text-sm font-medium text-indigo-600 hover:text-indigo-500"
-                    >
+                    <Button variant="link" onClick={() => setPage("all")}>
                       View All Initiatives &rarr;
-                    </button>
+                    </Button>
                   )}
                 </div>
                 {data.length > 0 ? (


### PR DESCRIPTION
- Extract out a common button component with 2 variants (for link-style and regular buttons)
- Add additional styles to address lack of hover cursor, better animated button transitions etc.
- Introduce CN function (like how shadcn components work) for merging tailwind styles.  Long term this project should just be updated to use ShadCN components if it grows.