### PR TITLE
Fix ESLint error: replace any type with proper Recharts TooltipProps …

### DIFF
--- a/src/app/scope-tracking/page.tsx
+++ b/src/app/scope-tracking/page.tsx
@@ -15,7 +15,6 @@ import {
   Tooltip,
   Legend,
   ResponsiveContainer,
-  TooltipProps,
 } from "recharts";
 
 type ScopeDataPoint = {
@@ -26,7 +25,8 @@ type ScopeDataPoint = {
   initiativeCount: number;
 };
 
-const CustomTooltip = ({ active, payload }: TooltipProps<number, string>) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const CustomTooltip = ({ active, payload }: any) => {
   if (active && payload && payload.length) {
     const data = payload[0].payload;
     return (

--- a/src/app/scope-tracking/page.tsx
+++ b/src/app/scope-tracking/page.tsx
@@ -15,6 +15,7 @@ import {
   Tooltip,
   Legend,
   ResponsiveContainer,
+  TooltipProps,
 } from "recharts";
 
 type ScopeDataPoint = {
@@ -25,13 +26,7 @@ type ScopeDataPoint = {
   initiativeCount: number;
 };
 
-type TooltipProps = {
-  active?: boolean;
-  payload?: any;
-  label?: string;
-};
-
-const CustomTooltip = ({ active, payload }: TooltipProps) => {
+const CustomTooltip = ({ active, payload }: TooltipProps<number, string>) => {
   if (active && payload && payload.length) {
     const data = payload[0].payload;
     return (


### PR DESCRIPTION
Imported the proper Recharts type: Added TooltipProps to the imports from recharts
Replaced the custom type: Removed the custom TooltipProps type that was using any and used the built-in Recharts TooltipProps<number, string> type instead