### PR TITLE
Enable static export and basePath for GitHub Pages deployment

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  // output: "export", // Commented out for development
+  output: "export",
   reactStrictMode: true,
-  // basePath: "/jiradisco", // Commented out for development
+  basePath: "/jiradisco",
 };
 
 export default nextConfig;


### PR DESCRIPTION
**The Problem**
The GitHub Actions build was failing because:
output: "export" was commented out, so Next.js wasn't creating the static ./out folder
basePath: "/jiradisco" was commented out, which is needed for GitHub Pages deployment
**The Fix**
I enabled both settings:
output: "export" - Tells Next.js to generate static HTML files in the ./out folder
basePath: "/jiradisco" - Sets the base path for GitHub Pages deployment
Verification
✅ Local build test passed
✅ ./out folder was created successfully
✅ All pages including scope-tracking.html were generated
✅ Changes committed and pushed